### PR TITLE
[feat] 이메일 인증 기능 구현

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,7 +31,6 @@ jobs:
 
       - name: 🐧 application.yml 파일을 생성 합니다.
         run: |
-          mkdir ./src/main/resources
           touch ./src/main/resources/application.yml
           echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application.yml # github actions에서 설정한 값을 application.yml 파일에 쓰기
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,14 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta" // querydsl JPAAnnotationProcessor 사용 지정
     annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 대응 코드
     annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 대응 코드
+
+    // 이메일 SMTP
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package org.gachon.checkmate.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
+import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
+import org.gachon.checkmate.domain.member.service.MemberService;
+import org.gachon.checkmate.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/email")
+    public ResponseEntity<SuccessResponse<?>> sendMail(@RequestBody EmailPostRequestDto emailPostRequestDto) {
+        final EmailResponseDto emailResponseDto = memberService.sendMail(emailPostRequestDto, "email");
+        return SuccessResponse.ok(emailResponseDto);
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -19,8 +19,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/email")
-    public ResponseEntity<SuccessResponse<?>> sendMail(@RequestBody EmailPostRequestDto emailPostRequestDto) {
-        final EmailResponseDto emailResponseDto = memberService.sendMail(emailPostRequestDto, "email");
+    public ResponseEntity<SuccessResponse<?>> sendMail(@RequestBody final EmailPostRequestDto emailPostRequestDto) {
+        final EmailResponseDto emailResponseDto = memberService.sendMail(emailPostRequestDto);
         return SuccessResponse.ok(emailResponseDto);
     }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/request/EmailPostRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/request/EmailPostRequestDto.java
@@ -1,0 +1,6 @@
+package org.gachon.checkmate.domain.member.dto.request;
+
+public record EmailPostRequestDto(
+        String email
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/response/EmailResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/response/EmailResponseDto.java
@@ -1,0 +1,6 @@
+package org.gachon.checkmate.domain.member.dto.response;
+
+public record EmailResponseDto(
+        String code
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -1,23 +1,13 @@
 package org.gachon.checkmate.domain.member.service;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
 import org.gachon.checkmate.global.config.auth.jwt.JwtProvider;
-import org.gachon.checkmate.global.error.exception.InternalServerException;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import org.gachon.checkmate.global.config.mail.MailProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.context.Context;
-import org.thymeleaf.spring6.SpringTemplateEngine;
-
-import java.util.Random;
-
-import static org.gachon.checkmate.global.error.ErrorCode.EMAIL_SEND_ERROR;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,37 +16,10 @@ import static org.gachon.checkmate.global.error.ErrorCode.EMAIL_SEND_ERROR;
 public class MemberService {
 
     private final JwtProvider jwtProvider;
-    private final JavaMailSender javaMailSender;
-    private final SpringTemplateEngine templateEngine;
+    private final MailProvider mailProvider;
 
-    public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto, String type) {
-        String authNum = createNumericCode();
-        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        try {
-            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-            mimeMessageHelper.setTo(emailPostRequestDto.email()); // 메일 수신자
-            mimeMessageHelper.setSubject("[CHECKMATE] 이메일 인증번호 발송"); // 메일 제목
-            mimeMessageHelper.setText(setContext(authNum, type), true); // 메일 본문
-            javaMailSender.send(mimeMessage);
-            return new EmailResponseDto(authNum);
-        } catch (MessagingException e) {
-            throw new InternalServerException(EMAIL_SEND_ERROR);
-        }
-    }
-
-    public static String createNumericCode() {
-        Random random = new Random();
-        StringBuilder code = new StringBuilder();
-        for (int i = 0; i < 6; i++) {
-            code.append(random.nextInt(10));
-        }
-        return code.toString();
-    }
-
-    public String setContext(String code, String type) {
-        Context context = new Context();
-        context.setVariable("code", code);
-        return templateEngine.process(type, context);
+    public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto) {
+        return mailProvider.sendMail(emailPostRequestDto, "email");
     }
 
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -19,7 +19,8 @@ public class MemberService {
     private final MailProvider mailProvider;
 
     public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto) {
-        return mailProvider.sendMail(emailPostRequestDto, "email");
+        String authNum = mailProvider.sendMail(emailPostRequestDto.email(), "email");
+        return new EmailResponseDto(authNum);
     }
 
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -1,0 +1,62 @@
+package org.gachon.checkmate.domain.member.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
+import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
+import org.gachon.checkmate.global.config.auth.jwt.JwtProvider;
+import org.gachon.checkmate.global.error.exception.InternalServerException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Random;
+
+import static org.gachon.checkmate.global.error.ErrorCode.EMAIL_SEND_ERROR;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+    private final JwtProvider jwtProvider;
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto, String type) {
+        String authNum = createNumericCode();
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(emailPostRequestDto.email()); // 메일 수신자
+            mimeMessageHelper.setSubject("[CHECKMATE] 이메일 인증번호 발송"); // 메일 제목
+            mimeMessageHelper.setText(setContext(authNum, type), true); // 메일 본문
+            javaMailSender.send(mimeMessage);
+            return new EmailResponseDto(authNum);
+        } catch (MessagingException e) {
+            throw new InternalServerException(EMAIL_SEND_ERROR);
+        }
+    }
+
+    public static String createNumericCode() {
+        Random random = new Random();
+        StringBuilder code = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            code.append(random.nextInt(10));
+        }
+        return code.toString();
+    }
+
+    public String setContext(String code, String type) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process(type, context);
+    }
+
+}

--- a/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
     private final CorsConfig corsConfig;
     private final JwtProvider jwtProvider;
 
-    private static final String[] whiteList = {"/"};
+    private static final String[] whiteList = {"/", "api/member/email"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/src/main/java/org/gachon/checkmate/global/config/mail/MailProvider.java
+++ b/src/main/java/org/gachon/checkmate/global/config/mail/MailProvider.java
@@ -40,7 +40,7 @@ public class MailProvider {
         }
     }
 
-    public static String createNumericCode() {
+    private static String createNumericCode() {
         Random random = new Random();
         StringBuilder code = new StringBuilder();
         for (int i = 0; i < 6; i++) {
@@ -49,7 +49,7 @@ public class MailProvider {
         return code.toString();
     }
 
-    public String setContext(String code, String type) {
+    private String setContext(String code, String type) {
         Context context = new Context();
         context.setVariable("code", code);
         return templateEngine.process(type, context);

--- a/src/main/java/org/gachon/checkmate/global/config/mail/MailProvider.java
+++ b/src/main/java/org/gachon/checkmate/global/config/mail/MailProvider.java
@@ -1,0 +1,58 @@
+package org.gachon.checkmate.global.config.mail;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
+import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
+import org.gachon.checkmate.global.error.exception.InternalServerException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Random;
+
+import static org.gachon.checkmate.global.error.ErrorCode.EMAIL_SEND_ERROR;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MailProvider {
+
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto, String type) {
+        String authNum = createNumericCode();
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(emailPostRequestDto.email()); // 메일 수신자
+            mimeMessageHelper.setSubject("[CHECKMATE] 이메일 인증번호 발송"); // 메일 제목
+            mimeMessageHelper.setText(setContext(authNum, type), true); // 메일 본문
+            javaMailSender.send(mimeMessage);
+            return new EmailResponseDto(authNum);
+        } catch (MessagingException e) {
+            throw new InternalServerException(EMAIL_SEND_ERROR);
+        }
+    }
+
+    public static String createNumericCode() {
+        Random random = new Random();
+        StringBuilder code = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            code.append(random.nextInt(10));
+        }
+        return code.toString();
+    }
+
+    public String setContext(String code, String type) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process(type, context);
+    }
+
+}

--- a/src/main/java/org/gachon/checkmate/global/config/mail/MailProvider.java
+++ b/src/main/java/org/gachon/checkmate/global/config/mail/MailProvider.java
@@ -5,7 +5,6 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
-import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
 import org.gachon.checkmate.global.error.exception.InternalServerException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -25,16 +24,16 @@ public class MailProvider {
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
 
-    public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto, String type) {
+    public String sendMail(String email, String type) {
         String authNum = createNumericCode();
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         try {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-            mimeMessageHelper.setTo(emailPostRequestDto.email()); // 메일 수신자
+            mimeMessageHelper.setTo(email); // 메일 수신자
             mimeMessageHelper.setSubject("[CHECKMATE] 이메일 인증번호 발송"); // 메일 제목
             mimeMessageHelper.setText(setContext(authNum, type), true); // 메일 본문
             javaMailSender.send(mimeMessage);
-            return new EmailResponseDto(authNum);
+            return authNum;
         } catch (MessagingException e) {
             throw new InternalServerException(EMAIL_SEND_ERROR);
         }

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -49,7 +49,8 @@ public enum ErrorCode {
     /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body style="font-family: Arial, sans-serif; background-color: #f8f8f8; text-align: center;">
+
+<div style="max-width: 600px; margin: 100px auto; padding: 20px; background-color: #ffffff; border: 1px solid #ff6600; border-radius: 10px;">
+    <p style="color: #ff6600;"><strong>기숙사 룸메이트 매칭 플랫폼 Check-mate</strong></p>
+    <p style="color: #000000;">반갑습니다.</p>
+    <p>아래 코드를 인증번호 입력 란에 입력해주세요.</p>
+
+    <div style="font-size: 24px; margin-top: 20px; padding: 10px; background-color: #ff6600; color: #ffffff; border-radius: 5px;">
+        <span th:text="${code}"></span>
+    </div>
+</div>
+
+</body>
+
+</html>


### PR DESCRIPTION
## Related Issue 🪢

- close : #6 

## Summary 🌿

- 이메일 인증 관련 세팅
- 이메일 인증 API 구현
- 비밀번호 재설정 이메일 인증/회원가입 이메일 인증에 범용적으로 사용하도록 워딩이나 함수를 구성했습니다.
- 인증번호는 6자리 숫자 랜덤으로 구현했습니다.

## Before i request PR review 🧤

- 코드리뷰/수정할 점/질문/피드백 환영 촤하하 
