### PR TITLE
[feat] 로그인 및 회원가입 기능

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -4,16 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
 import org.gachon.checkmate.domain.member.dto.request.MemberSignInRequestDto;
 import org.gachon.checkmate.domain.member.dto.request.MemberSignUpRequestDto;
+import org.gachon.checkmate.domain.member.dto.request.PasswordResetRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignInResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
 import org.gachon.checkmate.domain.member.service.MemberService;
 import org.gachon.checkmate.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
@@ -40,4 +38,9 @@ public class MemberController {
         return SuccessResponse.ok(memberSignInResponseDto);
     }
 
+    @PatchMapping("/reset")
+    public ResponseEntity<SuccessResponse<?>> setPassword(@RequestBody final PasswordResetRequestDto passwordResetRequestDto){
+        memberService.setPassword(passwordResetRequestDto);
+        return SuccessResponse.ok(null);
+    }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -29,7 +29,7 @@ public class MemberController {
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<?>> signUp(@RequestBody final MemberSignUpRequestDto memberSignUpRequestDto){
         final MemberSignUpResponseDto memberSignUpResponseDto = memberService.signUp(memberSignUpRequestDto);
-        return SuccessResponse.ok(memberSignUpResponseDto);
+        return SuccessResponse.created(memberSignUpResponseDto);
     }
 
     @PostMapping("/signin")

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -2,7 +2,9 @@ package org.gachon.checkmate.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
+import org.gachon.checkmate.domain.member.dto.request.MemberSignUpRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
+import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
 import org.gachon.checkmate.domain.member.service.MemberService;
 import org.gachon.checkmate.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
@@ -23,4 +25,11 @@ public class MemberController {
         final EmailResponseDto emailResponseDto = memberService.sendMail(emailPostRequestDto);
         return SuccessResponse.ok(emailResponseDto);
     }
+
+    @PostMapping("/signup")
+    public ResponseEntity<SuccessResponse<?>> signUp(@RequestBody final MemberSignUpRequestDto memberSignUpRequestDto){
+        final MemberSignUpResponseDto memberSignUpResponseDto = memberService.signUp(memberSignUpRequestDto);
+        return SuccessResponse.ok(memberSignUpResponseDto);
+    }
+
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -2,8 +2,10 @@ package org.gachon.checkmate.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
+import org.gachon.checkmate.domain.member.dto.request.MemberSignInRequestDto;
 import org.gachon.checkmate.domain.member.dto.request.MemberSignUpRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
+import org.gachon.checkmate.domain.member.dto.response.MemberSignInResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
 import org.gachon.checkmate.domain.member.service.MemberService;
 import org.gachon.checkmate.global.common.SuccessResponse;
@@ -30,6 +32,12 @@ public class MemberController {
     public ResponseEntity<SuccessResponse<?>> signUp(@RequestBody final MemberSignUpRequestDto memberSignUpRequestDto){
         final MemberSignUpResponseDto memberSignUpResponseDto = memberService.signUp(memberSignUpRequestDto);
         return SuccessResponse.ok(memberSignUpResponseDto);
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<SuccessResponse<?>> signIn(@RequestBody final MemberSignInRequestDto memberSignInRequestDto){
+        final MemberSignInResponseDto memberSignInResponseDto = memberService.signIn(memberSignInRequestDto);
+        return SuccessResponse.ok(memberSignInResponseDto);
     }
 
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/request/MemberSignInRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/request/MemberSignInRequestDto.java
@@ -1,0 +1,7 @@
+package org.gachon.checkmate.domain.member.dto.request;
+
+public record MemberSignInRequestDto(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/request/MemberSignUpRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/request/MemberSignUpRequestDto.java
@@ -1,0 +1,15 @@
+package org.gachon.checkmate.domain.member.dto.request;
+
+import org.gachon.checkmate.domain.member.entity.GenderType;
+import org.gachon.checkmate.domain.member.entity.MbtiType;
+
+public record MemberSignUpRequestDto(
+        String email,
+        String password,
+        String name,
+        String school,
+        String major,
+        MbtiType mbtiType,
+        GenderType genderType
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/request/PasswordResetRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/request/PasswordResetRequestDto.java
@@ -1,0 +1,7 @@
+package org.gachon.checkmate.domain.member.dto.request;
+
+public record PasswordResetRequestDto(
+        String email,
+        String newPassword
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberSignInResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberSignInResponseDto.java
@@ -1,0 +1,20 @@
+package org.gachon.checkmate.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MemberSignInResponseDto(
+        Long memberId,
+        String accessToken,
+        String refreshToken
+) {
+    public static MemberSignInResponseDto of(Long memberId,
+                                             String accessToken,
+                                             String refreshToken) {
+        return MemberSignInResponseDto.builder()
+                .memberId(memberId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberSignUpResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberSignUpResponseDto.java
@@ -4,14 +4,17 @@ import lombok.Builder;
 
 @Builder
 public record MemberSignUpResponseDto(
+        Long memberId,
         String name,
         String accessToken,
         String refreshToken
 ) {
-    public static MemberSignUpResponseDto of(String name,
+    public static MemberSignUpResponseDto of(Long memberId,
+                                             String name,
                                              String accessToken,
                                              String refreshToken) {
         return MemberSignUpResponseDto.builder()
+                .memberId(memberId)
                 .name(name)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberSignUpResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberSignUpResponseDto.java
@@ -1,0 +1,20 @@
+package org.gachon.checkmate.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MemberSignUpResponseDto(
+        String name,
+        String accessToken,
+        String refreshToken
+) {
+    public static MemberSignUpResponseDto of(String name,
+                                             String accessToken,
+                                             String refreshToken) {
+        return MemberSignUpResponseDto.builder()
+                .name(name)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/ProfileImageType.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/ProfileImageType.java
@@ -1,0 +1,16 @@
+package org.gachon.checkmate.domain.member.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum ProfileImageType {
+
+    PROFILE_1("https://checkmate-dormitory-bucket.s3.ap-northeast-2.amazonaws.com/checkmate-profile1.png"),
+    PROFILE_2("https://example.com/profile2.jpg"),
+    PROFILE_3("https://example.com/profile3.jpg");
+
+    private final String imageUrl;
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
@@ -30,8 +30,6 @@ public class User extends BaseTimeEntity {
     private String profile;
     private String school;
     private String major;
-    @Convert(converter = RoomTypeConverter.class)
-    private RoomType roomType;
     @Convert(converter = MbtiTypeConverter.class)
     private MbtiType mbtiType;
     @Convert(converter = GenderTypeConverter.class)

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
@@ -55,4 +55,8 @@ public class User extends BaseTimeEntity {
                 .gender(gender)
                 .build();
     }
+
+    public void setPassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
@@ -42,4 +42,17 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user")
     @Builder.Default
     private List<Scrap> scrapList = new ArrayList<>();
+
+    public static User createUser(String email, String storedPassword, String name, String school, String major, MbtiType mbti, GenderType gender){
+        return User.builder()
+                .email(email)
+                .password(storedPassword)
+                .name(name)
+                .profile(ProfileImageType.PROFILE_1.getImageUrl())
+                .school(school)
+                .major(major)
+                .mbtiType(mbti)
+                .gender(gender)
+                .build();
+    }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
@@ -5,7 +5,7 @@ import lombok.*;
 import org.gachon.checkmate.domain.checkList.entity.CheckList;
 import org.gachon.checkmate.domain.member.converter.GenderTypeConverter;
 import org.gachon.checkmate.domain.member.converter.MbtiTypeConverter;
-import org.gachon.checkmate.domain.member.converter.RoomTypeConverter;
+import org.gachon.checkmate.domain.post.converter.RoomTypeConverter;
 import org.gachon.checkmate.domain.post.entity.Post;
 import org.gachon.checkmate.domain.scrap.entity.Scrap;
 import org.gachon.checkmate.global.common.BaseTimeEntity;

--- a/src/main/java/org/gachon/checkmate/domain/member/repository/UserRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/repository/UserRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/repository/UserRepository.java
@@ -3,6 +3,9 @@ package org.gachon.checkmate.domain.member.repository;
 import org.gachon.checkmate.domain.member.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/repository/UserRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package org.gachon.checkmate.domain.member.repository;
+
+import org.gachon.checkmate.domain.member.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -3,16 +3,23 @@ package org.gachon.checkmate.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
+import org.gachon.checkmate.domain.member.dto.request.MemberSignInRequestDto;
 import org.gachon.checkmate.domain.member.dto.request.MemberSignUpRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
+import org.gachon.checkmate.domain.member.dto.response.MemberSignInResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
 import org.gachon.checkmate.domain.member.entity.User;
 import org.gachon.checkmate.domain.member.repository.UserRepository;
 import org.gachon.checkmate.global.config.auth.jwt.JwtProvider;
 import org.gachon.checkmate.global.config.mail.MailProvider;
+import org.gachon.checkmate.global.error.exception.EntityNotFoundException;
+import org.gachon.checkmate.global.error.exception.UnauthorizedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.gachon.checkmate.global.error.ErrorCode.INVALID_PASSWORD;
+import static org.gachon.checkmate.global.error.ErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -35,6 +42,16 @@ public class MemberService {
         String accessToken = issueNewToken(newMemberId);
         String refreshToken = issueNewToken(newMemberId);
         return MemberSignUpResponseDto.of(newMemberId, memberSignUpRequestDto.name(), accessToken, refreshToken);
+    }
+
+    public MemberSignInResponseDto signIn(MemberSignInRequestDto memberSignInRequestDto){
+        User user = getUserFromEmail(memberSignInRequestDto.email());
+        if (!authenticatePassword(memberSignInRequestDto.password(), user.getPassword())) {
+            throw new UnauthorizedException(INVALID_PASSWORD);
+        }
+        String accessToken = issueNewToken(user.getId());
+        String refreshToken = issueNewToken(user.getId());
+        return MemberSignInResponseDto.of(user.getId(), accessToken, refreshToken);
     }
 
     private String issueNewToken(Long memberId) {
@@ -61,5 +78,11 @@ public class MemberService {
     private boolean authenticatePassword(String enteredPassword, String storedPassword) {
         return passwordEncoder.matches(enteredPassword, storedPassword);
     }
+
+    private User getUserFromEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+    }
+
 
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -3,9 +3,14 @@ package org.gachon.checkmate.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
+import org.gachon.checkmate.domain.member.dto.request.MemberSignUpRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
+import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
+import org.gachon.checkmate.domain.member.entity.User;
+import org.gachon.checkmate.domain.member.repository.UserRepository;
 import org.gachon.checkmate.global.config.auth.jwt.JwtProvider;
 import org.gachon.checkmate.global.config.mail.MailProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,10 +22,44 @@ public class MemberService {
 
     private final JwtProvider jwtProvider;
     private final MailProvider mailProvider;
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
 
     public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto) {
         String authNum = mailProvider.sendMail(emailPostRequestDto.email(), "email");
         return new EmailResponseDto(authNum);
+    }
+
+    public MemberSignUpResponseDto signUp(MemberSignUpRequestDto memberSignUpRequestDto) {
+        Long newMemberId = createMember(memberSignUpRequestDto);
+        String accessToken = issueNewToken(newMemberId);
+        String refreshToken = issueNewToken(newMemberId);
+        return MemberSignUpResponseDto.of(memberSignUpRequestDto.name(), accessToken, refreshToken);
+    }
+
+    private String issueNewToken(Long memberId) {
+        return jwtProvider.getIssueToken(memberId, true);
+    }
+
+    private Long createMember(MemberSignUpRequestDto memberSignUpRequestDto) {
+        User newUser = User.createUser(
+                memberSignUpRequestDto.email(),
+                encodedPassword(memberSignUpRequestDto.password()),
+                memberSignUpRequestDto.name(),
+                memberSignUpRequestDto.school(),
+                memberSignUpRequestDto.major(),
+                memberSignUpRequestDto.mbtiType(),
+                memberSignUpRequestDto.genderType()
+        );
+        return userRepository.save(newUser).getId();
+    }
+
+    private String encodedPassword(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    private boolean authenticatePassword(String enteredPassword, String storedPassword) {
+        return passwordEncoder.matches(enteredPassword, storedPassword);
     }
 
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
         Long newMemberId = createMember(memberSignUpRequestDto);
         String accessToken = issueNewToken(newMemberId);
         String refreshToken = issueNewToken(newMemberId);
-        return MemberSignUpResponseDto.of(memberSignUpRequestDto.name(), accessToken, refreshToken);
+        return MemberSignUpResponseDto.of(newMemberId, memberSignUpRequestDto.name(), accessToken, refreshToken);
     }
 
     private String issueNewToken(Long memberId) {

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
 import org.gachon.checkmate.domain.member.dto.request.MemberSignInRequestDto;
 import org.gachon.checkmate.domain.member.dto.request.MemberSignUpRequestDto;
+import org.gachon.checkmate.domain.member.dto.request.PasswordResetRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignInResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
@@ -51,6 +52,11 @@ public class MemberService {
         String accessToken = issueNewAccessToken(user.getId());
         String refreshToken = issueNewRefreshToken(user.getId());
         return MemberSignInResponseDto.of(user.getId(), accessToken, refreshToken);
+    }
+
+    public void setPassword(PasswordResetRequestDto passwordResetRequestDto){
+        User user = getUserFromEmail(passwordResetRequestDto.email());
+        user.setPassword(encodedPassword(passwordResetRequestDto.newPassword()));
     }
 
     private void validatePassword(String enteredPassword, String storedPassword) {

--- a/src/main/java/org/gachon/checkmate/domain/post/converter/RoomTypeConverter.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/converter/RoomTypeConverter.java
@@ -1,4 +1,4 @@
-package org.gachon.checkmate.domain.member.converter;
+package org.gachon.checkmate.domain.post.converter;
 
 import jakarta.persistence.Converter;
 import org.gachon.checkmate.domain.member.entity.RoomType;

--- a/src/main/java/org/gachon/checkmate/domain/post/converter/RoomTypeConverter.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/converter/RoomTypeConverter.java
@@ -1,7 +1,7 @@
 package org.gachon.checkmate.domain.post.converter;
 
 import jakarta.persistence.Converter;
-import org.gachon.checkmate.domain.member.entity.RoomType;
+import org.gachon.checkmate.domain.post.entity.RoomType;
 import org.gachon.checkmate.global.utils.AbstractEnumCodeAttributeConverter;
 
 @Converter

--- a/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
@@ -3,7 +3,7 @@ package org.gachon.checkmate.domain.post.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.gachon.checkmate.domain.checkList.entity.PostCheckList;
-import org.gachon.checkmate.domain.member.converter.RoomTypeConverter;
+import org.gachon.checkmate.domain.post.converter.RoomTypeConverter;
 import org.gachon.checkmate.domain.member.entity.RoomType;
 import org.gachon.checkmate.domain.member.entity.User;
 import org.gachon.checkmate.domain.post.converter.ImportantKeyTypeConverter;

--- a/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.gachon.checkmate.domain.checkList.entity.PostCheckList;
 import org.gachon.checkmate.domain.post.converter.RoomTypeConverter;
-import org.gachon.checkmate.domain.member.entity.RoomType;
 import org.gachon.checkmate.domain.member.entity.User;
 import org.gachon.checkmate.domain.post.converter.ImportantKeyTypeConverter;
 import org.gachon.checkmate.domain.post.converter.SimilarityKeyTypeConverter;

--- a/src/main/java/org/gachon/checkmate/domain/post/entity/RoomType.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/entity/RoomType.java
@@ -1,4 +1,4 @@
-package org.gachon.checkmate.domain.member.entity;
+package org.gachon.checkmate.domain.post.entity;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
     private final CorsConfig corsConfig;
     private final JwtProvider jwtProvider;
 
-    private static final String[] whiteList = {"/", "api/member/email"};
+    private static final String[] whiteList = {"/", "api/member/email", "api/member/signup"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
     private final CorsConfig corsConfig;
     private final JwtProvider jwtProvider;
 
-    private static final String[] whiteList = {"/", "api/member/email", "api/member/signup"};
+    private static final String[] whiteList = {"/", "api/member/email", "api/member/signup", "api/member/signin"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -46,5 +48,10 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "리프레시 토큰의 값이 올바르지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     /**
      * 403 Forbidden
@@ -36,6 +37,7 @@ public enum ErrorCode {
      */
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "엔티티를 찾을 수 없습니다."),
     CHECK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "체크리스트를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
      * 409 Conflict
      */
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
 
     /**
      * 500 Internal Server Error


### PR DESCRIPTION
## Related Issue 🪢

- close : #10 

## Summary 🌿

- RoomType/RoomType Converter를 member->post로 옮겼습니다.
- 비밀번호 암호화 처리
- major는 별도의 major DB에서 검색해서 정보 조회한 뒤 프론트에서 string으로 보내주는 방식 맞을까요? (일단 string 입력으로 구현함)
- 회원가입 API
- 로그인 API
- 이메일 중복확인 처리 - 인증번호 API에 추가
- 비밀번호 재설정 API

## Before i request PR review 🧤

- jwt 잘 썼는지 봐주세요.. 엉엉
