### PR TITLE
[feat] 키워드 게시물 조회 api 구현 

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
@@ -7,12 +7,7 @@ import org.gachon.checkmate.global.common.SuccessResponse;
 import org.gachon.checkmate.global.config.auth.UserId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/post")
@@ -24,7 +19,15 @@ public class PostController {
     public ResponseEntity<SuccessResponse<?>> searchTextPost(@UserId final Long userId,
                                                              @RequestParam final String text,
                                                              final Pageable pageable) {
-        final List<PostSearchResponseDto> responseDto = postService.searchTextPost(userId, text, pageable);
+        final PostSearchResponseDto responseDto = postService.searchTextPost(userId, text, pageable);
+        return SuccessResponse.ok(responseDto);
+    }
+
+    @GetMapping("/search/{key}")
+    public ResponseEntity<SuccessResponse<?>> searchKeyWordPost(@UserId final Long userId,
+                                                                @PathVariable final String key,
+                                                                final Pageable pageable) {
+        final PostSearchResponseDto responseDto = postService.searchKeyWordPost(userId, key, pageable);
         return SuccessResponse.ok(responseDto);
     }
 }

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostSearchElementResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostSearchElementResponseDto.java
@@ -1,0 +1,29 @@
+package org.gachon.checkmate.domain.post.dto.response;
+
+import lombok.Builder;
+import org.gachon.checkmate.domain.post.dto.support.PostSearchDto;
+
+@Builder
+public record PostSearchElementResponseDto(
+        String title,
+        String content,
+        String importantKey,
+        String similarityKey,
+        int scrapCount,
+        int remainDate,
+        int accuracy
+) {
+    public static PostSearchElementResponseDto of(PostSearchDto postSearchDto,
+                                                  int remainDate,
+                                                  int accuracy) {
+        return PostSearchElementResponseDto.builder()
+                .title(postSearchDto.title())
+                .content(postSearchDto.content())
+                .importantKey(postSearchDto.importantKey().getDesc())
+                .similarityKey(postSearchDto.similarityKey().getDesc())
+                .scrapCount(postSearchDto.scrapCount())
+                .remainDate(remainDate)
+                .accuracy(accuracy)
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostSearchResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostSearchResponseDto.java
@@ -1,29 +1,19 @@
 package org.gachon.checkmate.domain.post.dto.response;
 
 import lombok.Builder;
-import org.gachon.checkmate.domain.post.dto.support.PostSearchDto;
+
+import java.util.List;
 
 @Builder
 public record PostSearchResponseDto(
-        String title,
-        String content,
-        String importantKey,
-        String similarityKey,
-        int scrapCount,
-        int remainDate,
-        int accuracy
-) {
-    public static PostSearchResponseDto of(PostSearchDto postSearchDto,
-                                           int remainDate,
-                                           int accuracy) {
+        List<PostSearchElementResponseDto> results,
+        int totalPages,
+        long totalElements) {
+    public static PostSearchResponseDto of(List<PostSearchElementResponseDto> results, int totalPages, long totalElements) {
         return PostSearchResponseDto.builder()
-                .title(postSearchDto.title())
-                .content(postSearchDto.content())
-                .importantKey(postSearchDto.importantKey().getDesc())
-                .similarityKey(postSearchDto.similarityKey().getDesc())
-                .scrapCount(postSearchDto.scrapCount())
-                .remainDate(remainDate)
-                .accuracy(accuracy)
+                .results(results)
+                .totalPages(totalPages)
+                .totalElements(totalElements)
                 .build();
     }
 }

--- a/src/main/java/org/gachon/checkmate/domain/post/repository/PostQuerydslRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/repository/PostQuerydslRepository.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.gachon.checkmate.domain.post.dto.support.PostSearchDto;
 import org.gachon.checkmate.domain.post.dto.support.QPostSearchDto;
+import org.gachon.checkmate.domain.post.entity.ImportantKeyType;
 import org.gachon.checkmate.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,32 @@ import static org.gachon.checkmate.domain.post.entity.QPost.post;
 public class PostQuerydslRepository {
     private final JPAQueryFactory queryFactory;
 
+    public Page<PostSearchDto> searchKeyPost(ImportantKeyType importantKeyType, Pageable pageable) {
+        List<PostSearchDto> content = queryFactory
+                .select(new QPostSearchDto(
+                        post.title,
+                        post.content,
+                        post.importantKeyType,
+                        post.similarityKeyType,
+                        post.endDate,
+                        post.scrapList.size(),
+                        postCheckList
+                ))
+                .from(post)
+                .leftJoin(post.postCheckList, postCheckList)
+                .where(
+                        containKeyWordCondition(importantKeyType),
+                        validatePostDate()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Post> countQuery = queryFactory
+                .selectFrom(post);
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+    }
+
     public Page<PostSearchDto> searchTextPost(String text, Pageable pageable) {
         List<PostSearchDto> content = queryFactory
                 .select(new QPostSearchDto(
@@ -37,8 +64,8 @@ public class PostQuerydslRepository {
                 .from(post)
                 .leftJoin(post.postCheckList, postCheckList)
                 .where(
-                        post.title.contains(text),
-                        post.endDate.before(LocalDate.now())
+                        containTextCondition(text),
+                        validatePostDate()
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -47,5 +74,17 @@ public class PostQuerydslRepository {
         JPAQuery<Post> countQuery = queryFactory
                 .selectFrom(post);
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+    }
+
+    private BooleanExpression containKeyWordCondition(ImportantKeyType importantKeyType) {
+        return post.importantKeyType.eq(importantKeyType);
+    }
+
+    private BooleanExpression containTextCondition(String text) {
+        return post.title.contains(text);
+    }
+
+    private BooleanExpression validatePostDate() {
+        return post.endDate.before(LocalDate.now());
     }
 }


### PR DESCRIPTION
## Related Issue 🪢

- close : #13 

## Summary 🌿

- 키워드 게시물 조회 api 구현했습니다.
- 게시물을 검색하기 위한 여러 api에서 공통으로 dto를 사용하기 위해 elements dto와 최종 결과 dto를 만들어 재사용하였습니다.
- 검색 쿼리에서 조건을 메서드로 분리하여 유사조건에 대한 재사용성을 높였습니다. (나중에 api가 많아지면 이렇게 하는게 좋다고 하네요..)

## Before i request PR review 🧤

- 오타 찾아주세요~
