### PR TITLE
[fix] keyword 중심 search 정렬 기준 반영

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
@@ -26,8 +26,9 @@ public class PostController {
     @GetMapping("/search/{key}")
     public ResponseEntity<SuccessResponse<?>> searchKeyWordPost(@UserId final Long userId,
                                                                 @PathVariable final String key,
+                                                                @RequestParam final String type,
                                                                 final Pageable pageable) {
-        final PostSearchResponseDto responseDto = postService.searchKeyWordPost(userId, key, pageable);
+        final PostSearchResponseDto responseDto = postService.searchKeyWordPost(userId, key, type, pageable);
         return SuccessResponse.ok(responseDto);
     }
 }

--- a/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
@@ -23,7 +23,7 @@ public class PostController {
         return SuccessResponse.ok(responseDto);
     }
 
-    @GetMapping("/search/{key}")
+    @GetMapping("/{key}")
     public ResponseEntity<SuccessResponse<?>> searchKeyWordPost(@UserId final Long userId,
                                                                 @PathVariable final String key,
                                                                 @RequestParam final String type,

--- a/src/main/java/org/gachon/checkmate/domain/post/entity/SortType.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/entity/SortType.java
@@ -1,0 +1,17 @@
+package org.gachon.checkmate.domain.post.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.gachon.checkmate.global.utils.EnumField;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum SortType implements EnumField {
+    DATE("1", "register"),
+    REMAIN_DATE("2", "remain date"),
+    ACCURACY("3", "accuracy");
+
+    private String code;
+    private String desc;
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/repository/PostQuerydslRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/repository/PostQuerydslRepository.java
@@ -41,8 +41,6 @@ public class PostQuerydslRepository {
                         containKeyWordCondition(importantKeyType),
                         validatePostDate()
                 )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Post> countQuery = queryFactory

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_ENUM_CODE(HttpStatus.BAD_REQUEST, "잘못된 Enum class code 입니다."),
+    INVALID_PAGING_SIZE(HttpStatus.BAD_REQUEST, "잘못된 Paging 크기입니다."),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/org/gachon/checkmate/global/utils/PagingUtils.java
+++ b/src/main/java/org/gachon/checkmate/global/utils/PagingUtils.java
@@ -1,0 +1,20 @@
+package org.gachon.checkmate.global.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.gachon.checkmate.global.error.exception.InvalidValueException;
+
+import java.util.List;
+
+import static org.gachon.checkmate.global.error.ErrorCode.INVALID_PAGING_SIZE;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PagingUtils {
+    public static <T> List<T> convertPaging(List<T> dataList, long page, int size) {
+        if (dataList.size() <= page * size)
+            throw new InvalidValueException(INVALID_PAGING_SIZE);
+        int startIndex = (int) page * size;
+        int endIndex = Math.min(dataList.size(), (int) page * (size + 1));
+        return dataList.subList(startIndex, endIndex);
+    }
+}


### PR DESCRIPTION
## Related Issue 🪢

- close : #15 

## Summary 🌿

- keyword 중심 search 정렬 기준 반영
- paging 의존성을 쿼리에서 service단으로 분리
- 최신 등록일자를 default로 쿼리 검색 진행
- 각 검색 조건에 맞는 정렬 기준으로 정렬 O(n log n) 시간 복잡도 사용
- custom paging util을 구현하여 paging을 사용

## Before i request PR review 🧤

- 오타 찾아주세요