### PR TITLE
[feat] 게시글 상세 조회 api 구현

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package org.gachon.checkmate.domain.post.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.gachon.checkmate.domain.post.dto.response.PostDetailResponseDto;
 import org.gachon.checkmate.domain.post.dto.response.PostSearchResponseDto;
 import org.gachon.checkmate.domain.post.service.PostService;
 import org.gachon.checkmate.global.common.SuccessResponse;
@@ -18,17 +19,14 @@ public class PostController {
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getAllPosts(@UserId final Long userId,
                                                           @RequestParam final String type,
-                                                          final Pageable pageable){
+                                                          final Pageable pageable) {
         final PostSearchResponseDto responseDto = postService.getAllPosts(userId, type, pageable);
         return SuccessResponse.ok(responseDto);
     }
 
-    @GetMapping("/{key}")
-    public ResponseEntity<SuccessResponse<?>> searchKeyWordPost(@UserId final Long userId,
-                                                                @PathVariable final String key,
-                                                                @RequestParam final String type,
-                                                                final Pageable pageable) {
-        final PostSearchResponseDto responseDto = postService.searchKeyWordPost(userId, key, type, pageable);
+    @GetMapping("/{id}")
+    public ResponseEntity<SuccessResponse<?>> getPostDetails(@PathVariable("id") final Long postId) {
+        final PostDetailResponseDto responseDto = postService.getPostDetails(postId);
         return SuccessResponse.ok(responseDto);
     }
 
@@ -37,6 +35,15 @@ public class PostController {
                                                              @RequestParam final String text,
                                                              final Pageable pageable) {
         final PostSearchResponseDto responseDto = postService.searchTextPost(userId, text, pageable);
+        return SuccessResponse.ok(responseDto);
+    }
+
+    @GetMapping("/search/{key}")
+    public ResponseEntity<SuccessResponse<?>> searchKeyWordPost(@UserId final Long userId,
+                                                                @PathVariable final String key,
+                                                                @RequestParam final String type,
+                                                                final Pageable pageable) {
+        final PostSearchResponseDto responseDto = postService.searchKeyWordPost(userId, key, type, pageable);
         return SuccessResponse.ok(responseDto);
     }
 }

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostDetailResponseDto.java
@@ -1,0 +1,26 @@
+package org.gachon.checkmate.domain.post.dto.response;
+
+import lombok.Builder;
+import org.gachon.checkmate.domain.checkList.dto.response.CheckListResponseDto;
+import org.gachon.checkmate.domain.post.dto.support.PostDetailDto;
+
+@Builder
+public record PostDetailResponseDto(
+        String name,
+        String major,
+        String profile,
+        String gender,
+        String mbti,
+        CheckListResponseDto checkList
+) {
+    public static PostDetailResponseDto of(PostDetailDto postDetailDto, CheckListResponseDto checkList) {
+        return PostDetailResponseDto.builder()
+                .name(postDetailDto.name())
+                .major(postDetailDto.major())
+                .profile(postDetailDto.profile())
+                .gender(postDetailDto.gender().getDesc())
+                .mbti(postDetailDto.mbti().getDesc())
+                .checkList(checkList)
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostSearchElementResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostSearchElementResponseDto.java
@@ -5,6 +5,7 @@ import org.gachon.checkmate.domain.post.dto.support.PostSearchDto;
 
 @Builder
 public record PostSearchElementResponseDto(
+        Long postId,
         String title,
         String content,
         String importantKey,
@@ -17,6 +18,7 @@ public record PostSearchElementResponseDto(
                                                   int remainDate,
                                                   int accuracy) {
         return PostSearchElementResponseDto.builder()
+                .postId(postSearchDto.postId())
                 .title(postSearchDto.title())
                 .content(postSearchDto.content())
                 .importantKey(postSearchDto.importantKey().getDesc())

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/support/PostDetailDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/support/PostDetailDto.java
@@ -1,0 +1,26 @@
+package org.gachon.checkmate.domain.post.dto.support;
+
+import com.querydsl.core.annotations.QueryProjection;
+import org.gachon.checkmate.domain.checkList.entity.PostCheckList;
+import org.gachon.checkmate.domain.member.entity.GenderType;
+import org.gachon.checkmate.domain.member.entity.MbtiType;
+import org.gachon.checkmate.domain.member.entity.ProfileImageType;
+
+public record PostDetailDto(
+        String major,
+        MbtiType mbti,
+        GenderType gender,
+        String name,
+        String profile,
+        PostCheckList postCheckList
+) {
+    @QueryProjection
+    public PostDetailDto(String major, MbtiType mbti, GenderType gender, String name, String profile, PostCheckList postCheckList) {
+        this.major = major;
+        this.mbti = mbti;
+        this.gender = gender;
+        this.name = name;
+        this.profile = profile;
+        this.postCheckList = postCheckList;
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/support/PostSearchDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/support/PostSearchDto.java
@@ -8,6 +8,7 @@ import org.gachon.checkmate.domain.post.entity.SimilarityKeyType;
 import java.time.LocalDate;
 
 public record PostSearchDto(
+        Long postId,
         String title,
         String content,
         ImportantKeyType importantKey,
@@ -17,7 +18,8 @@ public record PostSearchDto(
         PostCheckList postCheckList
 ) {
     @QueryProjection
-    public PostSearchDto(String title, String content, ImportantKeyType importantKey, SimilarityKeyType similarityKey, LocalDate endDate, int scrapCount, PostCheckList postCheckList) {
+    public PostSearchDto(Long postId, String title, String content, ImportantKeyType importantKey, SimilarityKeyType similarityKey, LocalDate endDate, int scrapCount, PostCheckList postCheckList) {
+        this.postId = postId;
         this.title = title;
         this.content = content;
         this.importantKey = importantKey;

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "엔티티를 찾을 수 없습니다."),
     CHECK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "체크리스트를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저를 찾을 수 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 게시글을 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
## Related Issue 🪢

- close : #20 

## Summary 🌿

- 게시글 상세 조회 api 구현했습니다.
- 단일 post 조회를 위해 restful api 원칙에 따라 id를 이용한 pathvariable을 사용하였습니다.
- 쿼리 조회시 optional을 이용해 null을 허용하고 service 단에서 예외 처리를 해주었습니다.

## Before i request PR review 🧤

- 코드리뷰로 확인 부탁하는 사항
