### PR TITLE
[feat] 마이페이지 조회 및 로그인 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -58,4 +58,11 @@ public class MemberController {
         memberService.signOut(userId);
         return SuccessResponse.ok(null);
     }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<SuccessResponse<?>> changeProfileImg(@UserId final Long userId,
+                                                               @RequestBody ProfileImgRequestDto profileImgRequestDto){
+        memberService.changeProfileImg(userId, profileImgRequestDto);
+        return SuccessResponse.ok(null);
+    }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -8,8 +8,10 @@ import org.gachon.checkmate.domain.member.dto.request.PasswordResetRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignInResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
+import org.gachon.checkmate.domain.member.dto.response.MypageResponseDto;
 import org.gachon.checkmate.domain.member.service.MemberService;
 import org.gachon.checkmate.global.common.SuccessResponse;
+import org.gachon.checkmate.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,5 +44,11 @@ public class MemberController {
     public ResponseEntity<SuccessResponse<?>> setPassword(@RequestBody final PasswordResetRequestDto passwordResetRequestDto){
         memberService.setPassword(passwordResetRequestDto);
         return SuccessResponse.ok(null);
+    }
+
+    @GetMapping("/mypage")
+    public ResponseEntity<SuccessResponse<?>> getMypage(@UserId final Long userId){
+        final MypageResponseDto mypageResponseDto = memberService.getMypage(userId);
+        return SuccessResponse.ok(mypageResponseDto);
     }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -1,14 +1,9 @@
 package org.gachon.checkmate.domain.member.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
-import org.gachon.checkmate.domain.member.dto.request.EmailPostRequestDto;
-import org.gachon.checkmate.domain.member.dto.request.MemberSignInRequestDto;
-import org.gachon.checkmate.domain.member.dto.request.MemberSignUpRequestDto;
-import org.gachon.checkmate.domain.member.dto.request.PasswordResetRequestDto;
-import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
-import org.gachon.checkmate.domain.member.dto.response.MemberSignInResponseDto;
-import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
-import org.gachon.checkmate.domain.member.dto.response.MypageResponseDto;
+import org.gachon.checkmate.domain.member.dto.request.*;
+import org.gachon.checkmate.domain.member.dto.response.*;
 import org.gachon.checkmate.domain.member.service.MemberService;
 import org.gachon.checkmate.global.common.SuccessResponse;
 import org.gachon.checkmate.global.config.auth.UserId;
@@ -50,5 +45,17 @@ public class MemberController {
     public ResponseEntity<SuccessResponse<?>> getMypage(@UserId final Long userId){
         final MypageResponseDto mypageResponseDto = memberService.getMypage(userId);
         return SuccessResponse.ok(mypageResponseDto);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<SuccessResponse<?>> reissue(@RequestBody final MemberReissueTokenRequestDto memberReissueTokenRequestDto) throws JsonProcessingException {
+        final MemberReissueTokenResponseDto memberReissueTokenResponseDto = memberService.reissue(memberReissueTokenRequestDto);
+        return SuccessResponse.ok(memberReissueTokenResponseDto);
+    }
+
+    @PostMapping("/signout")
+    public ResponseEntity<SuccessResponse<?>> signOut(@UserId final Long userId) {
+        memberService.signOut(userId);
+        return SuccessResponse.ok(null);
     }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/request/MemberReissueTokenRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/request/MemberReissueTokenRequestDto.java
@@ -1,0 +1,7 @@
+package org.gachon.checkmate.domain.member.dto.request;
+
+public record MemberReissueTokenRequestDto(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/request/ProfileImgRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/request/ProfileImgRequestDto.java
@@ -1,0 +1,8 @@
+package org.gachon.checkmate.domain.member.dto.request;
+
+import org.gachon.checkmate.domain.member.entity.ProfileImageType;
+
+public record ProfileImgRequestDto(
+        ProfileImageType profileImageType
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberReissueTokenResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/response/MemberReissueTokenResponseDto.java
@@ -1,0 +1,16 @@
+package org.gachon.checkmate.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MemberReissueTokenResponseDto(
+        String accessToken,
+        String refreshToken
+) {
+    public static MemberReissueTokenResponseDto of(String accessToken, String refreshToken){
+        return MemberReissueTokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/dto/response/MypageResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/dto/response/MypageResponseDto.java
@@ -1,0 +1,26 @@
+package org.gachon.checkmate.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MypageResponseDto(
+        String profileImg,
+        String name,
+        String major,
+        String gender,
+        String mbti
+) {
+    public static MypageResponseDto of(String profileImg,
+                                       String name,
+                                       String major,
+                                       String gender,
+                                       String mbti){
+        return MypageResponseDto.builder()
+                .profileImg(profileImg)
+                .name(name)
+                .major(major)
+                .gender(gender)
+                .mbti(mbti)
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/ProfileImageType.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/ProfileImageType.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 public enum ProfileImageType {
 
     PROFILE_1("https://checkmate-dormitory-bucket.s3.ap-northeast-2.amazonaws.com/checkmate-profile1.png"),
-    PROFILE_2("https://example.com/profile2.jpg"),
-    PROFILE_3("https://example.com/profile3.jpg");
+    PROFILE_2("https://checkmate-dormitory-bucket.s3.ap-northeast-2.amazonaws.com/checkmate-profile2.png"),
+    PROFILE_3("https://checkmate-dormitory-bucket.s3.ap-northeast-2.amazonaws.com/checkmate-profile3.png");
 
     private final String imageUrl;
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/RefreshToken.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/RefreshToken.java
@@ -1,0 +1,25 @@
+package org.gachon.checkmate.domain.member.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 60*60*24*7)
+public class RefreshToken {
+    @Id
+    private Long id;
+    private String refreshToken;
+
+    public static RefreshToken createRefreshToken(Long userId, String refreshToken) {
+        return RefreshToken.builder()
+                .id(userId)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
@@ -43,12 +43,12 @@ public class User extends BaseTimeEntity {
     @Builder.Default
     private List<Scrap> scrapList = new ArrayList<>();
 
-    public static User createUser(String email, String storedPassword, String name, String school, String major, MbtiType mbti, GenderType gender){
+    public static User createUser(String email, String storedPassword, String name, String school, String major, MbtiType mbti, GenderType gender, String profile){
         return User.builder()
                 .email(email)
                 .password(storedPassword)
                 .name(name)
-                .profile(ProfileImageType.PROFILE_1.getImageUrl())
+                .profile(profile)
                 .school(school)
                 .major(major)
                 .mbtiType(mbti)

--- a/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/entity/User.java
@@ -63,4 +63,8 @@ public class User extends BaseTimeEntity {
     public void setCheckList(CheckList checkList) {
         this.checkList = checkList;
     }
+
+    public void setProfile(String profile){
+        this.profile = profile;
+    }
 }

--- a/src/main/java/org/gachon/checkmate/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package org.gachon.checkmate.domain.member.repository;
+
+import org.gachon.checkmate.domain.member.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -124,6 +124,17 @@ public class MemberService {
         return userRepository.save(newUser).getId();
     }
 
+    public void changeProfileImg(Long userId, ProfileImgRequestDto profileImgRequestDto){
+        User user = findByIdOrThrow(userId);
+        String imageUrl = switch (profileImgRequestDto.profileImageType()) {
+            case PROFILE_1 -> ProfileImageType.PROFILE_1.getImageUrl();
+            case PROFILE_2 -> ProfileImageType.PROFILE_2.getImageUrl();
+            case PROFILE_3 -> ProfileImageType.PROFILE_3.getImageUrl();
+        };
+        user.setProfile(imageUrl);
+        userRepository.save(user);
+    }
+
     private String encodedPassword(String rawPassword) {
         return passwordEncoder.encode(rawPassword);
     }

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import org.gachon.checkmate.domain.member.dto.request.PasswordResetRequestDto;
 import org.gachon.checkmate.domain.member.dto.response.EmailResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignInResponseDto;
 import org.gachon.checkmate.domain.member.dto.response.MemberSignUpResponseDto;
+import org.gachon.checkmate.domain.member.dto.response.MypageResponseDto;
 import org.gachon.checkmate.domain.member.entity.User;
 import org.gachon.checkmate.domain.member.repository.UserRepository;
 import org.gachon.checkmate.global.config.auth.jwt.JwtProvider;
@@ -57,6 +58,21 @@ public class MemberService {
     public void setPassword(PasswordResetRequestDto passwordResetRequestDto){
         User user = getUserFromEmail(passwordResetRequestDto.email());
         user.setPassword(encodedPassword(passwordResetRequestDto.newPassword()));
+    }
+
+    public MypageResponseDto getMypage(Long userId){
+        User user = findByIdOrThrow(userId);
+        return MypageResponseDto.of(user.getProfile(),
+                user.getName(),
+                user.getMajor(),
+                user.getGender().getDesc(),
+                user.getMbtiType().getDesc()
+        );
+    }
+
+    private User findByIdOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
     }
 
     private void validatePassword(String enteredPassword, String storedPassword) {

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gachon.checkmate.domain.member.dto.request.*;
 import org.gachon.checkmate.domain.member.dto.response.*;
+import org.gachon.checkmate.domain.member.entity.ProfileImageType;
 import org.gachon.checkmate.domain.member.entity.RefreshToken;
 import org.gachon.checkmate.domain.member.entity.User;
 import org.gachon.checkmate.domain.member.repository.RefreshTokenRepository;
@@ -17,6 +18,7 @@ import org.gachon.checkmate.global.error.exception.InvalidValueException;
 import org.gachon.checkmate.global.error.exception.UnauthorizedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.regex.Pattern;
+import java.util.Random;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +37,7 @@ public class MemberService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private static final String PASSWORD_REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$";
+    private static final Random random = new Random();
 
     public EmailResponseDto sendMail(EmailPostRequestDto emailPostRequestDto) {
         checkDuplicateEmail(emailPostRequestDto.email());
@@ -107,6 +110,7 @@ public class MemberService {
     }
 
     private Long createMember(MemberSignUpRequestDto memberSignUpRequestDto) {
+        ProfileImageType randomProfile = getRandomProfileImage();
         User newUser = User.createUser(
                 memberSignUpRequestDto.email(),
                 encodedPassword(memberSignUpRequestDto.password()),
@@ -114,7 +118,8 @@ public class MemberService {
                 memberSignUpRequestDto.school(),
                 memberSignUpRequestDto.major(),
                 memberSignUpRequestDto.mbtiType(),
-                memberSignUpRequestDto.genderType()
+                memberSignUpRequestDto.genderType(),
+                randomProfile.getImageUrl()
         );
         return userRepository.save(newUser).getId();
     }
@@ -169,6 +174,12 @@ public class MemberService {
     public void signOut(Long userId) {
         User user = findByIdOrThrow(userId);
         deleteRefreshToken(user);
+    }
+
+    private static ProfileImageType getRandomProfileImage() {
+        ProfileImageType[] values = ProfileImageType.values();
+        int randomIndex = random.nextInt(values.length);
+        return values[randomIndex];
     }
 
 }

--- a/src/main/java/org/gachon/checkmate/global/config/RedisConfig.java
+++ b/src/main/java/org/gachon/checkmate/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package org.gachon.checkmate.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?,?> redisTemplate(){
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
@@ -25,7 +25,12 @@ public class SecurityConfig {
     private final CorsConfig corsConfig;
     private final JwtProvider jwtProvider;
 
-    private static final String[] whiteList = {"/", "api/member/email", "api/member/signup", "api/member/signin"};
+    private static final String[] whiteList = {"/",
+            "api/member/email",
+            "api/member/signup",
+            "api/member/signin",
+            "api/member/reissue"
+    };
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_ENUM_CODE(HttpStatus.BAD_REQUEST, "잘못된 Enum class code 입니다."),
     INVALID_PAGING_SIZE(HttpStatus.BAD_REQUEST, "잘못된 Paging 크기입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 8~20자 대소문자 영문, 숫자, 특수문자의 조합이어야 합니다."),
 
     /**
      * 401 Unauthorized
@@ -26,7 +27,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "리프레시 토큰의 값이 올바르지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    NOT_MATCH_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     /**
      * 403 Forbidden

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     CHECK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "체크리스트를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 게시글을 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 리프레시 토큰을 찾을 수 없습니다. 다시 로그인해 주세요."),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
## Related Issue 🪢

- close : #22 

## Summary 🌿
- 마이페이지 조회 API 생성
- 로그인 API 로직에서 리프레시 토큰을 레디스에 저장하는 과정 추가
- 토큰 재발급 API 생성
- 로그아웃 API 생성
- 회원가입 시 비밀번호 예외처리 정규식 추가
- 프로필 사진 URL 업로드
- 회원가입 시 프로필 사진 랜덤으로 생성되게 처리
- 프로필 사진 변경 API 생성

## Before i request PR review 🧤
- 멤버는 일단 끝난듯용
