### PR TITLE
[refactor] 게시물 service 코드 정리

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
@@ -5,14 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.gachon.checkmate.domain.post.dto.request.PostCreateRequestDto;
 import org.gachon.checkmate.domain.post.dto.response.PostDetailResponseDto;
 import org.gachon.checkmate.domain.post.dto.response.PostSearchResponseDto;
-import org.gachon.checkmate.domain.post.dto.support.PostSearchCondition;
-import org.gachon.checkmate.domain.post.repository.PostQuerydslRepository;
 import org.gachon.checkmate.domain.post.service.PostService;
 import org.gachon.checkmate.global.common.SuccessResponse;
 import org.gachon.checkmate.global.config.auth.UserId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -23,10 +20,11 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getAllPosts(@UserId final Long userId,
+                                                          @RequestParam(required = false) final String key,
                                                           @RequestParam final String type,
                                                           @RequestParam(required = false) final String gender,
                                                           final Pageable pageable) {
-        final PostSearchResponseDto responseDto = postService.getAllPosts(userId, type, gender, pageable);
+        final PostSearchResponseDto responseDto = postService.getAllPosts(userId, key, type, gender, pageable);
         return SuccessResponse.ok(responseDto);
     }
 
@@ -41,16 +39,6 @@ public class PostController {
                                                              @RequestParam final String text,
                                                              final Pageable pageable) {
         final PostSearchResponseDto responseDto = postService.searchTextPost(userId, text, pageable);
-        return SuccessResponse.ok(responseDto);
-    }
-
-    @GetMapping("/search/{key}")
-    public ResponseEntity<SuccessResponse<?>> searchKeyWordPost(@UserId final Long userId,
-                                                                @PathVariable final String key,
-                                                                @RequestParam final String type,
-                                                                @RequestParam(required = false) final String gender,
-                                                                final Pageable pageable) {
-        final PostSearchResponseDto responseDto = postService.searchKeyWordPost(userId, key, type, gender, pageable);
         return SuccessResponse.ok(responseDto);
     }
 

--- a/src/main/java/org/gachon/checkmate/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/repository/PostCustomRepository.java
@@ -1,0 +1,15 @@
+package org.gachon.checkmate.domain.post.repository;
+
+import org.gachon.checkmate.domain.post.dto.support.PostDetailDto;
+import org.gachon.checkmate.domain.post.dto.support.PostSearchCondition;
+import org.gachon.checkmate.domain.post.dto.support.PostSearchDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface PostCustomRepository {
+    Optional<PostDetailDto> findPostDetail(Long postId);
+    Page<PostSearchDto> searchPosts(PostSearchCondition condition);
+    Page<PostSearchDto> searchTextPost(String text, Pageable pageable);
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/repository/PostCustomRepositoryImpl.java
@@ -11,7 +11,6 @@ import org.gachon.checkmate.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,10 +22,10 @@ import static org.gachon.checkmate.domain.post.entity.QPost.post;
 import static org.springframework.util.StringUtils.hasText;
 
 @RequiredArgsConstructor
-@Repository
-public class PostQuerydslRepository {
+public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory queryFactory;
 
+    @Override
     public Optional<PostDetailDto> findPostDetail(Long postId) {
         return Optional.ofNullable(queryFactory
                 .select(new QPostDetailDto(
@@ -46,6 +45,7 @@ public class PostQuerydslRepository {
                 .fetchOne());
     }
 
+    @Override
     public Page<PostSearchDto> searchPosts(PostSearchCondition condition) {
         List<PostSearchDto> content = queryFactory
                 .select(new QPostSearchDto(
@@ -74,6 +74,7 @@ public class PostQuerydslRepository {
         return PageableExecutionUtils.getPage(content, condition.pageable(), countQuery::fetchCount);
     }
 
+    @Override
     public Page<PostSearchDto> searchTextPost(String text, Pageable pageable) {
         List<PostSearchDto> content = queryFactory
                 .select(new QPostSearchDto(

--- a/src/main/java/org/gachon/checkmate/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/repository/PostRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
     boolean existsByTitle(String title);
 }


### PR DESCRIPTION
## Related Issue 🪢

- close : #29 

## Summary 🌿

- querydsl을 추상화하여 repository와 service의 의존성을 최소화했습니다.
- repository를 추상화하여 impl을 구현하지 않는 것이 요즘 트렌드라고 하지만, jpa repository와 querydsl을 같이 사용하기 때문에 추상화를 통해 의존성을 최소화하는 것이 더 좋은 방법이라고 생각되었습니다.
- 게시물을 조회하는 2가지 종류의 api를 하나로 합쳤습니다.
- keyword를 request parameter로 변경하여 null을 허용하는 방식을 선택했습니다.
- 개발자가 null을 지정하고 입력하는 것은 별로 좋지 못한 코드이기 때문에, 중복된 코드를 최소화하고, null을 주입하지 않도록 개선하였습니다.

## Before i request PR review 🧤

- 코드리뷰로 확인 부탁하는 사항
