### PR TITLE
[feat] 게시글 수정 및 상태 변경

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/checkList/entity/PostCheckList.java
+++ b/src/main/java/org/gachon/checkmate/domain/checkList/entity/PostCheckList.java
@@ -46,4 +46,13 @@ public class PostCheckList extends BaseTimeEntity {
         post.setPostCheckList(checkList);
         return checkList;
     }
+
+    public void updatePostCheckList(CheckListRequestDto checkListRequestDto) {
+        this.cleanType = checkListRequestDto.cleanType();
+        this.drinkType = checkListRequestDto.drinkType();
+        this.homeType = checkListRequestDto.homeType();
+        this.lifePatterType = checkListRequestDto.lifePatterType();
+        this.noiseType = checkListRequestDto.noiseType();
+        this.sleepType = checkListRequestDto.sleepType();
+    }
 }

--- a/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
@@ -62,6 +62,14 @@ public class PostController {
         return SuccessResponse.ok(responseDto);
     }
 
+    @PatchMapping("/state/{id}")
+    public ResponseEntity<SuccessResponse<?>> updatePostState(@UserId final Long userId,
+                                                              @PathVariable("id") final Long postId,
+                                                              @RequestBody @Valid final PostStateUpdateRequestDto requestDto) {
+        PostStateUpdateResponseDto responseDto = postService.updateMyPostState(userId, postId, requestDto);
+        return SuccessResponse.ok(responseDto);
+    }
+
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createPost(@UserId final Long userId,
                                                          @RequestBody @Valid final PostCreateRequestDto requestDto) {

--- a/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/controller/PostController.java
@@ -3,8 +3,12 @@ package org.gachon.checkmate.domain.post.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.gachon.checkmate.domain.post.dto.request.PostCreateRequestDto;
+import org.gachon.checkmate.domain.post.dto.request.PostUpdateRequestDto;
+import org.gachon.checkmate.domain.post.dto.request.PostStateUpdateRequestDto;
 import org.gachon.checkmate.domain.post.dto.response.PostDetailResponseDto;
 import org.gachon.checkmate.domain.post.dto.response.PostSearchResponseDto;
+import org.gachon.checkmate.domain.post.dto.response.PostStateUpdateResponseDto;
+import org.gachon.checkmate.domain.post.dto.response.PostUpdateResponseDto;
 import org.gachon.checkmate.domain.post.service.PostService;
 import org.gachon.checkmate.global.common.SuccessResponse;
 import org.gachon.checkmate.global.config.auth.UserId;
@@ -47,6 +51,14 @@ public class PostController {
     public ResponseEntity<SuccessResponse<?>> getMyPosts(@UserId final Long userId,
                                                          final Pageable pageable) {
         final PostSearchResponseDto responseDto = postService.getMyPosts(userId, pageable);
+        return SuccessResponse.ok(responseDto);
+    }
+
+    @PatchMapping("{id}")
+    public ResponseEntity<SuccessResponse<?>> updateMyPost(@UserId final Long userId,
+                                                           @PathVariable("id") final Long postId,
+                                                           @RequestBody @Valid final PostUpdateRequestDto requestDto) {
+        PostUpdateResponseDto responseDto = postService.updateMyPost(userId, postId, requestDto);
         return SuccessResponse.ok(responseDto);
     }
 

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/request/PostStateUpdateRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/request/PostStateUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package org.gachon.checkmate.domain.post.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.gachon.checkmate.domain.post.entity.PostState;
+
+public record PostStateUpdateRequestDto(
+        @NotNull(message = "게시글 상태를 입력해주세요") PostState postState
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/request/PostUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package org.gachon.checkmate.domain.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.gachon.checkmate.domain.checkList.dto.request.CheckListRequestDto;
+import org.gachon.checkmate.domain.post.entity.ImportantKeyType;
+import org.gachon.checkmate.domain.post.entity.RoomType;
+import org.gachon.checkmate.domain.post.entity.SimilarityKeyType;
+
+import java.time.LocalDate;
+
+public record PostUpdateRequestDto(
+        @NotBlank(message = "제목을 입력해주세요") String title,
+        @NotBlank(message = "내용을 입력해주세요") String content,
+        @NotNull(message = "중요 키워드를 입력해주세요") ImportantKeyType importantKey,
+        @NotNull(message = "유사도를 입력해주세요") SimilarityKeyType similarityKey,
+        @NotNull(message = "기숙사 유형을 입력해주세요") RoomType roomType,
+        @NotNull(message = "모집 마감기간을 입력해주세요") LocalDate endDate,
+        @NotNull(message = "체크리스트를 입력해주세요") CheckListRequestDto checkList
+) {
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostStateUpdateResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostStateUpdateResponseDto.java
@@ -1,0 +1,17 @@
+package org.gachon.checkmate.domain.post.dto.response;
+
+import lombok.Builder;
+import org.gachon.checkmate.domain.post.entity.Post;
+
+@Builder
+public record PostStateUpdateResponseDto (
+        Long postId,
+        String postState
+) {
+    public static PostStateUpdateResponseDto of(Post post) {
+        return PostStateUpdateResponseDto.builder()
+                .postId(post.getId())
+                .postState(post.getPostState().getDesc())
+                .build();
+    }
+}

--- a/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostUpdateResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/dto/response/PostUpdateResponseDto.java
@@ -1,0 +1,32 @@
+package org.gachon.checkmate.domain.post.dto.response;
+
+import lombok.Builder;
+import org.gachon.checkmate.domain.checkList.dto.response.CheckListResponseDto;
+import org.gachon.checkmate.domain.post.entity.Post;
+
+import java.time.LocalDate;
+
+@Builder
+public record PostUpdateResponseDto(
+        Long postId,
+        String title,
+        String content,
+        String importantKey,
+        String similarityKey,
+        String roomType,
+        LocalDate endDate,
+        CheckListResponseDto checkList
+) {
+    public static PostUpdateResponseDto of(Post post, CheckListResponseDto checkListResponseDto) {
+        return PostUpdateResponseDto.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .importantKey(post.getImportantKeyType().getDesc())
+                .similarityKey(post.getSimilarityKeyType().getDesc())
+                .roomType(post.getRoomType().getDesc())
+                .checkList(checkListResponseDto)
+                .build();
+    }
+}
+

--- a/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
@@ -81,4 +81,7 @@ public class Post extends BaseTimeEntity {
         this.postCheckList.updatePostCheckList(postUpdateRequestDto.checkList());
     }
 
+    public void updatePostState(PostStateUpdateRequestDto postStateUpdateRequestDto) {
+        this.postState = postStateUpdateRequestDto.postState();
+    }
 }

--- a/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/entity/Post.java
@@ -9,6 +9,8 @@ import org.gachon.checkmate.domain.post.converter.PostStateConverter;
 import org.gachon.checkmate.domain.post.converter.RoomTypeConverter;
 import org.gachon.checkmate.domain.post.converter.SimilarityKeyTypeConverter;
 import org.gachon.checkmate.domain.post.dto.request.PostCreateRequestDto;
+import org.gachon.checkmate.domain.post.dto.request.PostStateUpdateRequestDto;
+import org.gachon.checkmate.domain.post.dto.request.PostUpdateRequestDto;
 import org.gachon.checkmate.domain.scrap.entity.Scrap;
 import org.gachon.checkmate.global.common.BaseTimeEntity;
 
@@ -51,6 +53,7 @@ public class Post extends BaseTimeEntity {
                 .title(postCreateRequestDto.title())
                 .content(postCreateRequestDto.content())
                 .endDate(postCreateRequestDto.endDate())
+                .postState(PostState.RECRUITING)
                 .roomType(postCreateRequestDto.roomType())
                 .importantKeyType(postCreateRequestDto.importantKey())
                 .similarityKeyType(postCreateRequestDto.similarityKey())
@@ -67,4 +70,15 @@ public class Post extends BaseTimeEntity {
     public void addScrap(Scrap scrap) {
         this.scrapList.add(scrap);
     }
+
+    public void updatePost(PostUpdateRequestDto postUpdateRequestDto) {
+        this.title = postUpdateRequestDto.title();
+        this.content = postUpdateRequestDto.content();
+        this.importantKeyType = postUpdateRequestDto.importantKey();
+        this.similarityKeyType = postUpdateRequestDto.similarityKey();
+        this.roomType = postUpdateRequestDto.roomType();
+        this.endDate = postUpdateRequestDto.endDate();
+        this.postCheckList.updatePostCheckList(postUpdateRequestDto.checkList());
+    }
+
 }

--- a/src/main/java/org/gachon/checkmate/domain/post/service/PostService.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/service/PostService.java
@@ -101,6 +101,14 @@ public class PostService {
         return PostUpdateResponseDto.of(post, checkListResponseDto);
     }
 
+    public PostStateUpdateResponseDto updateMyPostState(Long userId, Long postId, PostStateUpdateRequestDto requestDto) {
+        User user = getUserOrThrow(userId);
+        Post post = getPostOrThrow(postId);
+        validatePostWriter(user, post);
+        post.updatePostState(requestDto);
+        return PostStateUpdateResponseDto.of(post);
+    }
+
     private void validatePostWriter(User user, Post post) {
         if(!post.getUser().getId().equals(user.getId())) {
             throw new ForbiddenException(NOT_POST_WRITER);

--- a/src/main/java/org/gachon/checkmate/domain/post/service/PostService.java
+++ b/src/main/java/org/gachon/checkmate/domain/post/service/PostService.java
@@ -10,9 +10,9 @@ import org.gachon.checkmate.domain.checkList.repository.PostCheckListRepository;
 import org.gachon.checkmate.domain.member.entity.User;
 import org.gachon.checkmate.domain.member.repository.UserRepository;
 import org.gachon.checkmate.domain.post.dto.request.PostCreateRequestDto;
-import org.gachon.checkmate.domain.post.dto.response.PostDetailResponseDto;
-import org.gachon.checkmate.domain.post.dto.response.PostSearchElementResponseDto;
-import org.gachon.checkmate.domain.post.dto.response.PostSearchResponseDto;
+import org.gachon.checkmate.domain.post.dto.request.PostUpdateRequestDto;
+import org.gachon.checkmate.domain.post.dto.request.PostStateUpdateRequestDto;
+import org.gachon.checkmate.domain.post.dto.response.*;
 import org.gachon.checkmate.domain.post.dto.support.PostDetailDto;
 import org.gachon.checkmate.domain.post.dto.support.PostPagingSearchCondition;
 import org.gachon.checkmate.domain.post.dto.support.PostSearchCondition;
@@ -22,6 +22,7 @@ import org.gachon.checkmate.domain.post.entity.SortType;
 import org.gachon.checkmate.domain.post.repository.PostRepository;
 import org.gachon.checkmate.domain.scrap.repository.ScrapRepository;
 import org.gachon.checkmate.global.error.exception.EntityNotFoundException;
+import org.gachon.checkmate.global.error.exception.ForbiddenException;
 import org.gachon.checkmate.global.error.exception.InvalidValueException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -88,6 +89,22 @@ public class PostService {
         Page<PostSearchDto> postSearchList = getTextSearchResults(condition);
         List<PostSearchElementResponseDto> searchResults = createPostSearchResponseDto(postSearchList, checkList);
         return PostSearchResponseDto.of(searchResults, postSearchList.getTotalPages(), postSearchList.getTotalElements());
+    }
+
+    public PostUpdateResponseDto updateMyPost(Long userId, Long postId, PostUpdateRequestDto requestDto) {
+        User user = getUserOrThrow(userId);
+        Post post = getPostOrThrow(postId);
+        validatePostWriter(user, post);
+        validateAvailableEndDate(requestDto.endDate());
+        post.updatePost(requestDto);
+        CheckListResponseDto checkListResponseDto = createCheckListResponseDto(post.getPostCheckList());
+        return PostUpdateResponseDto.of(post, checkListResponseDto);
+    }
+
+    private void validatePostWriter(User user, Post post) {
+        if(!post.getUser().getId().equals(user.getId())) {
+            throw new ForbiddenException(NOT_POST_WRITER);
+        }
     }
 
     private List<PostSearchElementResponseDto> createPostSearchResponseDto(Page<PostSearchDto> postSearchDtoList, CheckList checkList) {
@@ -192,5 +209,10 @@ public class PostService {
 
     private boolean existPostInScrap(Long postId, Long userId) {
         return scrapRepository.existsByPostIdAndUserId(postId, userId);
+    }
+
+    private Post getPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
      * 403 Forbidden
      */
     FORBIDDEN(HttpStatus.FORBIDDEN, "리소스 접근 권한이 없습니다."),
+    NOT_POST_WRITER(HttpStatus.FORBIDDEN, "게시물을 수정할 권한이 없습니다. 작성자만이 게시물을 수정할 수 있습니다."),
 
     /**
      * 404 Not Found


### PR DESCRIPTION
## Related Issue 🪢

- close : #37 

## Summary 🌿

- 게시물 수정 API
- 게시물 모집 상태 변경 API

## Before i request PR review 🧤

- 서비스 코드에 두 API가 모두 동일하게
``` java
User user = getUserOrThrow(userId);
        Post post = getPostOrThrow(postId);
        validatePostWriter(user, post);
```
의 과정을 거쳐 3단계의 검증을 거치는데 이렇게 두는게 좋을지 아니면

``` java
// PostRepository.java
Optional<Post> findByIdAndUserId(Long id, Long userId);

// PostService.java
postRepository.findByIdAndUserId(postId, userId)
   .orElseThrow(() -> 어쩌고);
```

이렇게 하나의 과정으로 줄여서 검증을 진행하는게 좋을지 고민이됩니다. 

첫번째 방법은 검증이 자세한 이점이 있지만 쿼리가 유저, 포스트 부를때 각각 1번씩 나가 총 2번 호출되고
두번째 방법은 검증은 자세하게 하지 못하지만 한번의 쿼리로 해결한다는 점에서 이점이 있어보입니다.

많은 의견 부탁드립니다. 감사합니다.

- 또한 게시글 수정, 게시글 모집 상태 수정 때 현재는 response로 바뀐 값을 다시 넘겨주었는데 이렇게 값을 다시 넘겨주는게 좋을지 아니면 SuccessResponse.ok(null)정도로 빈 응답코드를 넘겨주면 좋을지 고민입니다.

주저리주저리 길어졌는데 모쪼록 천천히 잘부탁드립니다 🙇‍♂️🙇‍♂️