### PR TITLE
[feat] 비밀번호 변경 시에 사용할 이메일 인증 API 

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/controller/MemberController.java
@@ -23,6 +23,12 @@ public class MemberController {
         return SuccessResponse.ok(emailResponseDto);
     }
 
+    @PostMapping("/email/reset")
+    public ResponseEntity<SuccessResponse<?>> sendMailForResetPassword(@RequestBody final EmailPostRequestDto emailPostRequestDto) {
+        final EmailResponseDto emailResponseDto = memberService.sendMailForResetPassword(emailPostRequestDto);
+        return SuccessResponse.ok(emailResponseDto);
+    }
+
     @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<?>> signUp(@RequestBody final MemberSignUpRequestDto memberSignUpRequestDto){
         final MemberSignUpResponseDto memberSignUpResponseDto = memberService.signUp(memberSignUpRequestDto);

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -115,7 +115,7 @@ public class MemberService {
 
     private void checkAlreadySignedUpEmail(String email) {
         if (!userRepository.existsByEmail(email)) {
-            throw new ConflictException(UNAFFILIATED_EMAIL);
+            throw new EntityNotFoundException(UNAFFILIATED_EMAIL);
         }
     }
 

--- a/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
+++ b/src/main/java/org/gachon/checkmate/domain/member/service/MemberService.java
@@ -45,6 +45,12 @@ public class MemberService {
         return new EmailResponseDto(authNum);
     }
 
+    public EmailResponseDto sendMailForResetPassword(EmailPostRequestDto emailPostRequestDto) {
+        checkAlreadySignedUpEmail(emailPostRequestDto.email());
+        String authNum = mailProvider.sendMail(emailPostRequestDto.email(), "email");
+        return new EmailResponseDto(authNum);
+    }
+
     public MemberSignUpResponseDto signUp(MemberSignUpRequestDto memberSignUpRequestDto) {
         validatePassword(memberSignUpRequestDto.password());
         Long newMemberId = createMember(memberSignUpRequestDto);
@@ -104,6 +110,12 @@ public class MemberService {
     private void checkDuplicateEmail(String email) {
         if (userRepository.existsByEmail(email)) {
             throw new ConflictException(DUPLICATE_EMAIL);
+        }
+    }
+
+    private void checkAlreadySignedUpEmail(String email) {
+        if (!userRepository.existsByEmail(email)) {
+            throw new ConflictException(UNAFFILIATED_EMAIL);
         }
     }
 

--- a/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/gachon/checkmate/global/config/auth/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
     private static final String[] whiteList = {
             "/",
             "api/member/email",
+            "api/member/email/reset",
+            "api/member/reset",
             "api/member/signup",
             "api/member/signin",
             "api/member/reissue",

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     DUPLICATE_CHECK_LIST(HttpStatus.CONFLICT, "체크리스트가 이미 존재합니다."),
     DUPLICATE_POST_REPORT(HttpStatus.CONFLICT, "이전에 신고했던 게시물입니다."),
     DUPLICATE_CHATROOM_REPORT(HttpStatus.CONFLICT, "이전에 신고했던 채팅방입니다."),
+    UNAFFILIATED_EMAIL(HttpStatus.CONFLICT, "가입되지 않은 이메일입니다."),
 
     /**
      * 500 Internal Server Error

--- a/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
+++ b/src/main/java/org/gachon/checkmate/global/error/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 게시글을 찾을 수 없습니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 채팅방을 찾을 수 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 리프레시 토큰을 찾을 수 없습니다. 다시 로그인해 주세요."),
+    UNAFFILIATED_EMAIL(HttpStatus.CONFLICT, "가입되지 않은 이메일입니다."),
 
     /**
      * 405 Method Not Allowed
@@ -61,7 +62,6 @@ public enum ErrorCode {
     DUPLICATE_CHECK_LIST(HttpStatus.CONFLICT, "체크리스트가 이미 존재합니다."),
     DUPLICATE_POST_REPORT(HttpStatus.CONFLICT, "이전에 신고했던 게시물입니다."),
     DUPLICATE_CHATROOM_REPORT(HttpStatus.CONFLICT, "이전에 신고했던 채팅방입니다."),
-    UNAFFILIATED_EMAIL(HttpStatus.CONFLICT, "가입되지 않은 이메일입니다."),
 
     /**
      * 500 Internal Server Error


### PR DESCRIPTION
## Related Issue 🪢

- close : #46 

## Summary 🌿

- 비밀번호 변경 시에 사용할 이메일 인증 API 생성

## Before i request PR review 🧤

- 회원가입과의 차이점은 이미 중복된 이메일 검사의 역으로 이미 가입된 이메일 검사가 이루어진다는 점입니당
