### PR TITLE
[fix] 이전 채팅내역 조회 response 수정 및 response 경로 변경

### DIFF
--- a/src/main/java/org/gachon/checkmate/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/gachon/checkmate/domain/chat/controller/ChatController.java
@@ -27,22 +27,22 @@ public class ChatController {
     public void sendChat(@Header("simpSessionAttributes") Map<String, Object> simpSessionAttributes,
                              @Payload final ChatRequestDto request) {
         ChatResponseDto response = chatService.sendChat(simpSessionAttributes, request);
-        sendingOperations.convertAndSend("/queue/chat/"+simpSessionAttributes.get("roomId"), SocketBaseResponse.of(MessageType.CHAT, response));
+        sendingOperations.convertAndSend("/queue/chat/" + simpSessionAttributes.get("roomId"), SocketBaseResponse.of(MessageType.CHAT, response));
     }
 
     // 채팅방 정보 조회
     @MessageMapping("/room-list")
     public void getChatRoomList(@Header("simpSessionAttributes") Map<String, Object> simpSessionAttributes) {
         ChatRoomListResponseDto response = chatService.getChatRoomList(simpSessionAttributes);
-        sendingOperations.convertAndSend("/queue/user/"+simpSessionAttributes.get("userId"), SocketBaseResponse.of(MessageType.ROOM_LIST, response));
+        sendingOperations.convertAndSend("/queue/user/" + simpSessionAttributes.get("userId"), SocketBaseResponse.of(MessageType.ROOM_LIST, response));
     }
 
     // 이전 채팅 불러오기
     @MessageMapping("/chat-list")
     public void getChatList(@Header("simpSessionAttributes") Map<String, Object> simpSessionAttributes,
                                 @Payload final ChatListRequestDto request) {
-        final ChatListResponseDto response = chatService.getChatList(simpSessionAttributes, request);
-        sendingOperations.convertAndSend("/queue/user/" + simpSessionAttributes.get("userId"), SocketBaseResponse.of(MessageType.CHAT_LIST, response));
+        ChatListResponseDto response = chatService.getChatList(simpSessionAttributes, request);
+        sendingOperations.convertAndSend("/queue/chat/" + response.getChatRoomId(), SocketBaseResponse.of(MessageType.CHAT_LIST, response));
     }
 
     // 채팅방 입장하기

--- a/src/main/java/org/gachon/checkmate/domain/chat/dto/response/ChatListResponseDto.java
+++ b/src/main/java/org/gachon/checkmate/domain/chat/dto/response/ChatListResponseDto.java
@@ -15,6 +15,8 @@ public class ChatListResponseDto{
 
     private String chatRoomId;
 
+    private Long requestUserId;
+
     private ChatUserInfoDto chatUserInfoDto;
 
     @Builder.Default
@@ -26,9 +28,10 @@ public class ChatListResponseDto{
     @Builder.Default
     private Integer pageNumber = null;
 
-    public static ChatListResponseDto of(String chatRoomId, ChatUserInfoDto chatUserInfoDto) {
+    public static ChatListResponseDto of(String chatRoomId, Long requestUserId, ChatUserInfoDto chatUserInfoDto) {
         return ChatListResponseDto.builder()
                 .chatRoomId(chatRoomId)
+                .requestUserId(requestUserId)
                 .chatUserInfoDto(chatUserInfoDto)
                 .build();
     }

--- a/src/main/java/org/gachon/checkmate/domain/chat/service/ChatService.java
+++ b/src/main/java/org/gachon/checkmate/domain/chat/service/ChatService.java
@@ -98,7 +98,7 @@ public class ChatService {
         String chatRoomId = getChatRoomId(request.otherUserId(), userId);
 
         ChatUserInfoDto chatUserInfoDto = getUserChatUserInfoByUserId(request);
-        ChatListResponseDto response = ChatListResponseDto.of(chatRoomId, chatUserInfoDto);
+        ChatListResponseDto response = ChatListResponseDto.of(chatRoomId, userId, chatUserInfoDto);
 
         PageRequest pageRequest = PageRequest.of(request.pageNumber(), request.pageSize());
         Slice<Chat> chatMessages = chatRepository.findBeforeChatList(chatRoomId, pageRequest);


### PR DESCRIPTION
## Related Issue 🪢

- close : #57 

## Summary 🌿

- 프론트에 요구사항에 맞춰 이전 채팅 불러오는 메시지의 경로를 변경했습니다.
- 요청하는 user를 판단하기 위해 requestUserId를 response에 추가했습니다.

## Before i request PR review 🧤

- 코드리뷰로 확인 부탁하는 사항
